### PR TITLE
Fixed syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "prop-types": "^15.6.2",
     "react-native-loading-spinner-overlay": "^0.5.2",
-    "react-native-webview": "^7.5.1",
+    "react-native-webview": "^7.5.1"
   }
 }


### PR DESCRIPTION
This change is necessary since e.g. yarn fails when trying to add the package with a syntax error